### PR TITLE
Add issue templates for device, app, and feature feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/app_feedback.yml
@@ -1,0 +1,53 @@
+name: iOS app bug or feedback
+description: Something in the Flowe iPhone app — pairing, priorities, workouts, blocks, book sync, dictation.
+labels: ["app", "ios"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The app is closed-source, but this is the right place to report it —
+        one channel for everything beats two.
+
+  - type: input
+    id: version
+    attributes:
+      label: App version
+      description: "TestFlight shows this on the Flowe page; the app shows it in Settings → About."
+      placeholder: "e.g. 1.0 (42)"
+    validations:
+      required: true
+
+  - type: input
+    id: ios
+    attributes:
+      label: iPhone + iOS version
+      placeholder: "e.g. iPhone 14 Pro, iOS 26.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: paired
+    attributes:
+      label: Is a device paired?
+      options:
+        - "Yes — Xteink X3"
+        - "Yes — Xteink X4"
+        - "No, app only"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got instead. Screenshots welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: pairing
+    attributes:
+      label: If this is a pairing problem — what did the flow look like?
+      description: "How far did it get, what did the device screen show, did it ever connect before? Pairing is the flow we most want to smooth out."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Device bug (firmware)
+description: Something on the Xteink device itself misbehaves — flashing, screens, reader, sleep, buttons, battery.
+labels: ["bug", "firmware"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. The two fields that save the most
+        back-and-forth are **which device** and **which build** — please don't
+        skip them.
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      options:
+        - Xteink X3
+        - Xteink X4
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Flowe build
+      description: "Settings → About shows the version and build env (x3 / x4). If you can't get that far, say how you flashed and when you downloaded it."
+      placeholder: "e.g. 0.4.1 (x4), flashed from SD 2026-07-28"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: locked
+    attributes:
+      label: Was the device locked when you got it?
+      description: We're still building a definitive answer for locked devices — your data point helps.
+      options:
+        - "No — bought unlocked (Amazon / XTEINK site)"
+        - "Yes — unlocked it myself first"
+        - "Yes — still locked"
+        - "Not sure"
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: serial
+    attributes:
+      label: Serial log (optional, but it usually solves it outright)
+      description: "Plug in over USB and run `pio device monitor -b 115200`, or any serial terminal at 115200 baud. Paste whatever prints around the failure."
+      render: text
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        **Reader bug?** Please also name the book and its file size — most reader
+        failures are size- or structure-dependent, and "it says unreadable" on a
+        1 MB EPUB is a very different bug from a 200 KB one.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Beta testing (TestFlight)
+    url: https://www.flowe.ink
+    about: Sign up for the iOS beta and get build announcements — including X4 firmware releases.
+  - name: Does it work on a locked device?
+    url: https://github.com/andrewjiang/flowe-os#install
+    about: Short answer — if you can flash CrossPoint, you can flash Flowe. Long answer, and how to get back to CrossPoint, in the README.
+  - name: Android support
+    url: https://github.com/andrewjiang/flowe-os/issues
+    about: In progress, but it's a rebuild rather than a port — the Block feature rides iOS Screen Time, which has no Android equivalent. Search existing issues before filing a new one.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: Feature request
+description: Something you want Flowe to do that it doesn't.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Flowe runs on an ESP32-C3 with **no PSRAM** — after the framebuffer, SD,
+        BLE stack, and ANCS client, roughly 36 KB of heap is left. That budget is
+        why the radios take turns and why some obvious-sounding features are
+        expensive. Saying *what you're trying to do* rather than *what to build*
+        gets you a better answer, and sometimes a cheaper one that ships sooner.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: The situation, not the solution. "I want to study vocab on the bus" beats "add flashcards".
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: How do you handle it today?
+      description: Another app, paper, or not at all. This is the most useful field on the form — it says how much the problem actually costs you.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where would this live?
+      options:
+        - On the device
+        - In the iPhone app
+        - Both
+        - Not sure
+    validations:
+      required: false
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      options:
+        - Xteink X3
+        - Xteink X4
+        - Both
+        - Don't have one yet
+    validations:
+      required: false


### PR DESCRIPTION
Launch feedback is currently arriving by email, Reddit reply, DM, and TikTok comment, and this repo has zero open issues. One beta tester wrote: *"I'm not exactly sure what the best way is to send you my insights."* This gives that a front door.

**Four files, no code changes.**

| Template | Notes |
|---|---|
| `bug_report.yml` | Device bug. **Device + build are required** — the detail most reports omit and every X3/X4 diagnosis needs. Also asks whether the device shipped locked, to build a definitive answer for the three people who asked in the launch thread. Nudges reader bugs to name the book and its size. |
| `app_feedback.yml` | iOS app. Closed-source, but one channel beats two for a solo maintainer. Has a dedicated pairing-flow field. |
| `feature_request.yml` | Leads with the ESP32-C3's ~36 KB free heap so the constraint is visible up front, and asks what the person is *trying to do* rather than what to build. |
| `config.yml` | Pre-answers locked devices and Android right in the chooser, and links the TestFlight signup. |

Blank issues stay enabled — the templates are a nudge, not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)